### PR TITLE
Minor copyediting

### DIFF
--- a/src/searchStore.js
+++ b/src/searchStore.js
@@ -49,7 +49,7 @@ export const mutations = {
     })
     storeSavedExtracts(state.savedExtracts)
     state.newExtract = false
-    state.status = { type: 'success', scope: 'extract', message: 'The list ' + name + ' has successfully saved' }
+    state.status = { type: 'success', scope: 'extract', message: 'The list “' + name + '” has been saved' }
   },
   /**
   Delete a saved disaster list from storage
@@ -64,7 +64,7 @@ export const mutations = {
     mutations.clearCurrentExtract(state)
     state.newExtract = (extracts.length < 1)
     state.currentExtract = []
-    state.status = { type: 'success', scope: 'extract', message: 'The list ' + name + ' has been successfully deleted' }
+    state.status = { type: 'success', scope: 'extract', message: 'The list “' + name + '” has been deleted' }
   },
   /**
   Load a saved disaster list into the currentExtract (selected disaster list)

--- a/src/tour.js
+++ b/src/tour.js
@@ -161,7 +161,7 @@ let next = {
 let disasterLink = `
     <p>
     Don’t know the disaster ID?
-    Click here: <a target="_blank" href="https://www.fema.gov/disasters" class="tabbable">https://www.fema.gov/disasters</a>
+    Look it up in <a target="_blank" href="https://www.fema.gov/disasters" class="tabbable">FEMA’s disaster database</a>.
     </p>`
 disasterSearchTour.addStep('enter-search', {
   title: 'Search for a disaster',


### PR DESCRIPTION
* Eliminate “click here,” don’t display the URL on-screen.
* Fix the awkward grammar of “has successfully saved.”
* Standardize deleting/saving text relative to one another.
* Enclose list names in quotes.