### PR TITLE
Fix path for npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Install [git](https://git-scm.com/)
 
 #### Navigate to cloned directory
 
-`cd hud-disaster-data`
+`cd hud-disaster-data/app/`
 
 #### Install dependencies
 Run `npm install`


### PR DESCRIPTION
It's necessary to be in the `app/` subdirectory for `npm install` to work.